### PR TITLE
updated yolo dependencies

### DIFF
--- a/sensors/camera/CMakeLists.txt
+++ b/sensors/camera/CMakeLists.txt
@@ -17,7 +17,7 @@ find_package(pcl_conversions REQUIRED)
 find_package(pcl_ros REQUIRED)
 find_package(image_geometry REQUIRED)
 find_package(depth_image_proc REQUIRED)
-find_package(yolov8_msgs REQUIRED)
+find_package(yolo_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2 REQUIRED)
@@ -37,7 +37,7 @@ set(dependencies
   pcl_ros
   image_geometry
   depth_image_proc
-  yolov8_msgs
+  yolo_msgs
   geometry_msgs
   tf2_geometry_msgs
   tf2

--- a/sensors/camera/include/camera/YoloDetectionNode.hpp
+++ b/sensors/camera/include/camera/YoloDetectionNode.hpp
@@ -17,7 +17,7 @@
 
 #include <memory>
 
-#include "yolov8_msgs/msg/detection_array.hpp"
+#include "yolo_msgs/msg/detection_array.hpp"
 #include "vision_msgs/msg/detection2_d_array.hpp"
 
 #include "rclcpp/rclcpp.hpp"
@@ -31,9 +31,9 @@ public:
   YoloDetectionNode();
 
 private:
-  void detection_callback(const yolov8_msgs::msg::DetectionArray::ConstSharedPtr & msg);
+  void detection_callback(const yolo_msgs::msg::DetectionArray::ConstSharedPtr & msg);
 
-  rclcpp::Subscription<yolov8_msgs::msg::DetectionArray>::SharedPtr detection_sub_;
+  rclcpp::Subscription<yolo_msgs::msg::DetectionArray>::SharedPtr detection_sub_;
   rclcpp::Publisher<vision_msgs::msg::Detection2DArray>::SharedPtr detection_pub_;
 };
 

--- a/sensors/camera/package.xml
+++ b/sensors/camera/package.xml
@@ -19,7 +19,7 @@
   <depend>pcl_ros</depend>
   <depend>image_geometry</depend>
   <depend>depth_image_proc</depend>
-  <depend>yolov8_msgs</depend>
+  <depend>yolo_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2</depend>

--- a/sensors/camera/src/camera/YoloDetectionNode.cpp
+++ b/sensors/camera/src/camera/YoloDetectionNode.cpp
@@ -16,7 +16,7 @@
 
 #include "camera/YoloDetectionNode.hpp"
 
-#include "yolov8_msgs/msg/detection_array.hpp"
+#include "yolo_msgs/msg/detection_array.hpp"
 
 #include "vision_msgs/msg/detection2_d_array.hpp"
 #include "vision_msgs/msg/detection2_d.hpp"
@@ -33,7 +33,7 @@ using std::placeholders::_1;
 YoloDetectionNode::YoloDetectionNode()
 : Node("darkent_detection_node")
 {
-  detection_sub_ = create_subscription<yolov8_msgs::msg::DetectionArray>(
+  detection_sub_ = create_subscription<yolo_msgs::msg::DetectionArray>(
     "input_detection", rclcpp::SensorDataQoS().reliable(),
     std::bind(&YoloDetectionNode::detection_callback, this, _1));
   detection_pub_ = create_publisher<vision_msgs::msg::Detection2DArray>(
@@ -42,7 +42,7 @@ YoloDetectionNode::YoloDetectionNode()
 
 void
 YoloDetectionNode::detection_callback(
-  const yolov8_msgs::msg::DetectionArray::ConstSharedPtr & msg)
+  const yolo_msgs::msg::DetectionArray::ConstSharedPtr & msg)
 {
   vision_msgs::msg::Detection2DArray detection_array_msg;
   detection_array_msg.header = msg->header;

--- a/tf_seeker/package.xml
+++ b/tf_seeker/package.xml
@@ -8,7 +8,7 @@
   <license>Apache License, Version 2.0</license>
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>roscpp</depend>
+  <depend>rclcpp</depend>
   <depend>geometry_msgs</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2</depend>

--- a/thirdparty.repos
+++ b/thirdparty.repos
@@ -1,7 +1,7 @@
 repositories:
-  thirdparty/yolov8_ros:
+  thirdparty/yolo_ros:
     type: git
-    url: https://github.com/mgonzs13/yolov8_ros.git
+    url: https://github.com/mgonzs13/yolo_ros.git
     version: main
   thirdparty/cascade_lifecycle:
     type: git
@@ -13,9 +13,9 @@ repositories:
     version: master
   thirdparty/ros_astra_camera:
     type: git
-      url: https://github.com/Juancams/ros_astra_camera.git
-      version: rolling
+    url: https://github.com/Juancams/ros_astra_camera.git
+    version: rolling
   thirdparty/ros2_v4l2_camera:
     type: git
-      url: https://github.com/tier4/ros2_v4l2_camera.git
-      version: galactic
+    url: https://github.com/tier4/ros2_v4l2_camera.git
+    version: galactic


### PR DESCRIPTION
Hi,

This PR fixes `yolo_v8` dependencies, `third_parties.repos` structure and a typo in `tf_seeker rclcpp` pkg dependency.

Best,
Esther